### PR TITLE
Remove trailing slash if user suplied a trailing slash when adding game server

### DIFF
--- a/gameserverstatus/gameserverstatus.py
+++ b/gameserverstatus/gameserverstatus.py
@@ -375,8 +375,7 @@ class GameServerStatus(commands.Cog):
         """
         name = name.lower()
         
-        if address.endswith("/"):
-            address = address[:-1]
+        address = address.rstrip("/")
         
         async with self.config.guild(ctx.guild).servers() as cur_servers:
             if name in cur_servers:

--- a/gameserverstatus/gameserverstatus.py
+++ b/gameserverstatus/gameserverstatus.py
@@ -374,6 +374,10 @@ class GameServerStatus(commands.Cog):
         `[longname]`: The "full name" of this server.
         """
         name = name.lower()
+        
+        if address.endswith("/"):
+            address = address[:-1]
+        
         async with self.config.guild(ctx.guild).servers() as cur_servers:
             if name in cur_servers:
                 await ctx.send("A server with that name already exists.")


### PR DESCRIPTION
So someone fed the bot ``ss14://among.us/`` causing the bot to try to visit ``http://among.us//status``. Which the game server just responded with "not found"